### PR TITLE
Optimize return type of private `measurement._normalize_magnitudes()`

### DIFF
--- a/peprock/models/measurement.py
+++ b/peprock/models/measurement.py
@@ -78,12 +78,18 @@ class Measurement(
         self: Measurement[_MagnitudeT],
         other: Measurement[_MagnitudeS],
         /,
-    ) -> tuple[MetricPrefix, _MagnitudeT | float, _MagnitudeS | float]:
-        target_prefix: MetricPrefix = min(self.prefix, other.prefix)
+    ) -> tuple[
+        Measurement[_MagnitudeT] | Measurement[_MagnitudeS],
+        _MagnitudeT | float,
+        _MagnitudeS | float,
+    ]:
+        target: Measurement[_MagnitudeT] | Measurement[_MagnitudeS] = (
+            self if self.prefix <= other.prefix else other
+        )
         return (
-            target_prefix,
-            self.prefix.convert(self.magnitude, to=target_prefix),
-            other.prefix.convert(other.magnitude, to=target_prefix),
+            target,
+            self.prefix.convert(self.magnitude, to=target.prefix),
+            other.prefix.convert(other.magnitude, to=target.prefix),
         )
 
     def __lt__(self: Measurement, other: Measurement) -> bool:
@@ -206,13 +212,10 @@ class Measurement(
     def __add__(self: Measurement, other: Measurement) -> Measurement:
         """Return self + other."""
         if isinstance(other, Measurement) and self.unit == other.unit:
-            target_prefix, magnitude_self, magnitude_other = self._normalize_magnitudes(
-                other,
-            )
+            target, magnitude_self, magnitude_other = self._normalize_magnitudes(other)
             return dataclasses.replace(
-                self,
+                target,
                 magnitude=magnitude_self + magnitude_other,
-                prefix=target_prefix,
             )
 
         return NotImplemented
@@ -359,13 +362,10 @@ class Measurement(
     ) -> Measurement:
         """Return self % other."""
         if isinstance(other, Measurement) and self.unit == other.unit:
-            target_prefix, magnitude_self, magnitude_other = self._normalize_magnitudes(
-                other,
-            )
+            target, magnitude_self, magnitude_other = self._normalize_magnitudes(other)
             return dataclasses.replace(
-                self,
+                target,
                 magnitude=magnitude_self % magnitude_other,
-                prefix=target_prefix,
             )
 
         return NotImplemented
@@ -554,13 +554,10 @@ class Measurement(
     def __sub__(self: Measurement, other: Measurement) -> Measurement:
         """Return self - other."""
         if isinstance(other, Measurement) and self.unit == other.unit:
-            target_prefix, magnitude_self, magnitude_other = self._normalize_magnitudes(
-                other,
-            )
+            target, magnitude_self, magnitude_other = self._normalize_magnitudes(other)
             return dataclasses.replace(
-                self,
+                target,
                 magnitude=magnitude_self - magnitude_other,
-                prefix=target_prefix,
             )
 
         return NotImplemented
@@ -675,9 +672,7 @@ class Measurement(
             )
 
         if isinstance(other, Measurement) and self.unit == other.unit:
-            target_prefix, magnitude_self, magnitude_other = self._normalize_magnitudes(
-                other,
-            )
+            _, magnitude_self, magnitude_other = self._normalize_magnitudes(other)
             return magnitude_self / magnitude_other
 
         return NotImplemented

--- a/tests/models/test_measurement.py
+++ b/tests/models/test_measurement.py
@@ -141,89 +141,98 @@ def test_str(measurement):
     assert str(measurement) == format(measurement)
 
 
+_target: peprock.models.Measurement
+
+
 @pytest.mark.parametrize(
     ("measurement", "other", "expected"),
     [
         (
-            peprock.models.Measurement(
-                magnitude=12,
+            (
+                _target := peprock.models.Measurement(
+                    magnitude=12,
+                )
             ),
             peprock.models.Measurement(
                 magnitude=34,
             ),
-            (peprock.models.MetricPrefix.NONE, 12, 34),
+            (_target, 12, 34),
         ),
         (
             peprock.models.Measurement(
                 magnitude=12,
             ),
-            peprock.models.Measurement(
-                magnitude=34,
-                prefix=peprock.models.MetricPrefix.milli,
+            (
+                _target := peprock.models.Measurement(
+                    magnitude=34,
+                    prefix=peprock.models.MetricPrefix.milli,
+                )
             ),
-            (peprock.models.MetricPrefix.milli, 12_000, 34),
+            (_target, 12_000, 34),
         ),
         (
-            peprock.models.Measurement(
-                magnitude=12,
+            (
+                _target := peprock.models.Measurement(
+                    magnitude=12,
+                )
             ),
             peprock.models.Measurement(
                 magnitude=34,
                 prefix=peprock.models.MetricPrefix.kilo,
             ),
-            (peprock.models.MetricPrefix.NONE, 12, 34_000),
+            (_target, 12, 34_000),
         ),
         (
             peprock.models.Measurement(
                 magnitude=12,
                 prefix=peprock.models.MetricPrefix.mega,
             ),
-            peprock.models.Measurement(
-                magnitude=34,
-                prefix=peprock.models.MetricPrefix.kilo,
+            (
+                _target := peprock.models.Measurement(
+                    magnitude=34,
+                    prefix=peprock.models.MetricPrefix.kilo,
+                )
             ),
-            (peprock.models.MetricPrefix.kilo, 12_000, 34),
+            (_target, 12_000, 34),
         ),
         (
             peprock.models.Measurement(
                 magnitude=12.3,
                 prefix=peprock.models.MetricPrefix.mega,
             ),
-            peprock.models.Measurement(
-                magnitude=34.5,
-                prefix=peprock.models.MetricPrefix.kilo,
+            (
+                _target := peprock.models.Measurement(
+                    magnitude=34.5,
+                    prefix=peprock.models.MetricPrefix.kilo,
+                )
             ),
-            (peprock.models.MetricPrefix.kilo, 12_300.0, 34.5),
+            (_target, 12_300.0, 34.5),
         ),
         (
             peprock.models.Measurement(
                 magnitude=decimal.Decimal("12.3"),
                 prefix=peprock.models.MetricPrefix.mega,
             ),
-            peprock.models.Measurement(
-                magnitude=decimal.Decimal("34.5"),
-                prefix=peprock.models.MetricPrefix.kilo,
-            ),
             (
-                peprock.models.MetricPrefix.kilo,
-                decimal.Decimal("12300.0"),
-                decimal.Decimal("34.5"),
+                _target := peprock.models.Measurement(
+                    magnitude=decimal.Decimal("34.5"),
+                    prefix=peprock.models.MetricPrefix.kilo,
+                )
             ),
+            (_target, decimal.Decimal("12300.0"), decimal.Decimal("34.5")),
         ),
         (
             peprock.models.Measurement(
                 magnitude=fractions.Fraction("12.3"),
                 prefix=peprock.models.MetricPrefix.mega,
             ),
-            peprock.models.Measurement(
-                magnitude=fractions.Fraction("34.5"),
-                prefix=peprock.models.MetricPrefix.kilo,
-            ),
             (
-                peprock.models.MetricPrefix.kilo,
-                fractions.Fraction("12300"),
-                fractions.Fraction("34.5"),
+                _target := peprock.models.Measurement(
+                    magnitude=fractions.Fraction("34.5"),
+                    prefix=peprock.models.MetricPrefix.kilo,
+                )
             ),
+            (_target, fractions.Fraction("12300"), fractions.Fraction("34.5")),
         ),
     ],
     ids=lambda p: None if isinstance(p, tuple) else str(p),


### PR DESCRIPTION
Improves downstream usability